### PR TITLE
Improve Default Clipboard Size Limit

### DIFF
--- a/packages/tree_clipper_addon/src/tree_clipper_addon/preferences.py
+++ b/packages/tree_clipper_addon/src/tree_clipper_addon/preferences.py
@@ -4,16 +4,16 @@ import bpy
 class TreeClipperPreferences(bpy.types.AddonPreferences):
     bl_idname = __package__
 
-    max_clipboard_bytes: bpy.props.IntProperty(
-        name="Max Clipboard Bytes",
-        description="""Maximum clipboard size in bytes (UTF-8 encoded).
+    max_clipboard_megabyte: bpy.props.IntProperty(
+        name="Max. Clipboard Size (MB)",
+        description="""Maximum clipboard size in kilobytes (UTF-8 encoded).
 
 The export fails (safely) if the limit is exceeded.
 If this setting is beyond your system's capabilities,
 Blender might crash on export.
 
 The default value is somewhat conservative, but not guaranteed to be safe.""",
-        default=240_000,
+        default=10,
     )  # type: ignore
 
     show_advanced_options: bpy.props.BoolProperty(
@@ -22,14 +22,17 @@ The default value is somewhat conservative, but not guaranteed to be safe.""",
     )  # type: ignore
 
     def draw(self, context: bpy.types.Context) -> None:
-        self.layout.prop(self, "max_clipboard_bytes")
+        self.layout.prop(self, "max_clipboard_megabyte")
         self.layout.prop(self, "show_advanced_options")
 
 
 def get_max_clipboard_bytes():
-    return bpy.context.preferences.addons.get(  # ty:ignore[possibly-missing-attribute]
-        __package__  # ty:ignore[invalid-argument-type]
-    ).preferences.max_clipboard_bytes  # ty:ignore[possibly-missing-attribute]
+    return (
+        1_000_000
+        * bpy.context.preferences.addons.get(  # ty:ignore[possibly-missing-attribute]
+            __package__  # ty:ignore[invalid-argument-type]
+        ).preferences.max_clipboard_megabyte
+    )  # ty:ignore[possibly-missing-attribute]
 
 
 def get_show_advanced_options():


### PR DESCRIPTION
The limit was way too conservative.

Also, it wasn't possible to enter sensible values due to the limitations of the int property.