### PR TITLE
fix: compare node needs to import operation first

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
     "blender.addon.sourceDirectory": "./packages/tree_clipper_addon/src/tree_clipper_addon",
     "blender.addon.buildTaskName": "run-python-vendor",
     "python.testing.pytestArgs": [
-        "packages"
+        "packages",
+        "-s"
     ]
 }

--- a/packages/tree_clipper/src/tree_clipper/import_nodes.py
+++ b/packages/tree_clipper/src/tree_clipper/import_nodes.py
@@ -95,6 +95,13 @@ class Importer:
         # we need to lookup nodes and their sockets for linking them
         self.current_tree = None
 
+        # this is for backward compatibilty
+        # in some cases, disabled sockets do not exist in newer versions
+        # and we remove them from the serialization
+        # if links (or anything) reference them it we can avoid failure by
+        # checking that it's been removed intentionally
+        self.disabled_ids = set()
+
         self.report = ImportReport()
 
     ################################################################################

--- a/packages/tree_clipper/src/tree_clipper/import_nodes.py
+++ b/packages/tree_clipper/src/tree_clipper/import_nodes.py
@@ -339,9 +339,11 @@ From root: {from_root.to_str()}"""
         if self.debug_prints:
             print(f"{from_root.to_str()}: importing")
 
-        if serialization[ID] in self.getters:
-            raise RuntimeError(f"Double deserialization: {from_root.to_str()}")
-        self.getters[serialization[ID]] = getter
+        # hack for inserting fake stuff for backward compat
+        if serialization[ID] != -1:
+            if serialization[ID] in self.getters:
+                raise RuntimeError(f"Double deserialization: {from_root.to_str()}")
+            self.getters[serialization[ID]] = getter
 
         deserializer(
             self,

--- a/packages/tree_clipper/src/tree_clipper/import_nodes.py
+++ b/packages/tree_clipper/src/tree_clipper/import_nodes.py
@@ -428,10 +428,10 @@ From root: {from_root.to_str()}"""
                         continue
 
                     # https://github.com/Algebraic-UG/tree_clipper/issues/161
-                    if (
-                        prop.type in [PROP_TYPE_POINTER, PROP_TYPE_COLLECTION]
-                        and prop.fixed_type.__module__ != "_bpy_types"
-                    ):
+                    if prop.type in [
+                        PROP_TYPE_POINTER,
+                        PROP_TYPE_COLLECTION,
+                    ] and prop.fixed_type.__module__ not in ["_bpy_types", "bpy.types"]:
                         self.report.warnings.append(
                             f"""This property is missing in serialization.
 It appears to be from a third-party addon: {prop.fixed_type.__module__}

--- a/packages/tree_clipper/src/tree_clipper/import_nodes.py
+++ b/packages/tree_clipper/src/tree_clipper/import_nodes.py
@@ -150,7 +150,7 @@ class Importer:
 
     def register_as_deserialized(self, *, ident: int, getter: GETTER):
         if ident in self.getters:
-            raise RuntimeError("Double deserialization")
+            raise RuntimeError("Double deserialization: {ident}")
         self.getters[ident] = getter
 
     ################################################################################

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -1513,6 +1513,14 @@ class ColorManagedViewSettingsExporter(
         return data
 
 
+class CompareImporter(SpecificImporter[bpy.types.FunctionNodeCompare]):
+    """We need to trigger the import of operation first"""
+
+    def deserialize(self) -> None:
+        self.import_all_simple_writable_properties_and_list([INPUTS, OUTPUTS])
+        _import_node_parent(self)
+
+
 if (bpy.app.version[0] == 5 and bpy.app.version[1] >= 1) or bpy.app.version[0] > 5:
 
     class FieldToListExporter(SpecificExporter[bpy.types.GeometryNodeFieldToList]):

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -647,6 +647,37 @@ def compat_5_1(importer: Importer) -> bool:
     return current_is_at_least_5_2 and import_is_at_most_5_1
 
 
+# https://github.com/Algebraic-UG/tree_clipper/issues/210
+def insert_fake_quality_socket(serialization: dict[str, Any]):
+    fake_quality_socket = {
+        "id": -1,
+        "data": {
+            "name": "Quality",
+            "description": "",
+            "hide": False,
+            "enabled": True,
+            "link_limit": 1,
+            "show_expanded": False,
+            "hide_value": False,
+            "pin_gizmo": False,
+            "type": "INT",
+            "display_shape": "LINE",
+            "default_value": 3,
+        },
+    }
+    serialization[INPUTS][DATA][ITEMS].insert(5, fake_quality_socket)
+
+
+class SubdivisionSurfaceImporter(
+    SpecificImporter[bpy.types.GeometryNodeSubdivisionSurface]
+):
+    def deserialize(self):
+        if compat_5_1(self.importer):
+            insert_fake_quality_socket(self.serialization)
+        self.import_all_simple_writable_properties_and_list([INPUTS, OUTPUTS])
+        _import_node_parent(self)
+
+
 # https://github.com/Algebraic-UG/tree_clipper/issues/209
 def insert_fake_thin_wall_socket(serialization: dict[str, Any]):
     fake_thin_wall_socket = {

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -637,8 +637,39 @@ class CaptureAttrExporter(SpecificExporter[bpy.types.GeometryNodeCaptureAttribut
         )
 
 
+# https://github.com/Algebraic-UG/tree_clipper/issues/208
+def insert_fake_selection_socket(serialization: dict[str, Any]):
+    fake_selection_socket = {
+        "id": -1,
+        "data": {
+            "name": "Selection",
+            "description": "",
+            "hide": False,
+            "enabled": True,
+            "link_limit": 1,
+            "show_expanded": False,
+            "hide_value": True,
+            "pin_gizmo": False,
+            "type": "BOOLEAN",
+            "display_shape": "DIAMOND",
+            "default_value": True,  # maybe this should be false for output
+        },
+    }
+    serialization[INPUTS][DATA][ITEMS].insert(1, fake_selection_socket)
+    serialization[OUTPUTS][DATA][ITEMS].insert(1, fake_selection_socket)
+
+
 class CaptureAttrImporter(SpecificImporter[bpy.types.GeometryNodeCaptureAttribute]):
     def deserialize(self):
+        if (bpy.app.version[0] == 5 and bpy.app.version[1] >= 2) or bpy.app.version[
+            0
+        ] > 5:
+            if (
+                self.importer.blender_version[0] == 5
+                and self.importer.blender_version[1] < 2
+            ):
+                insert_fake_selection_socket(self.serialization)
+
         self.import_all_simple_writable_properties_and_list(
             # ordering is important, the capture_items implicitly create sockets
             [CAPTURE_ITEMS, ACTIVE_INDEX, INPUTS, OUTPUTS],

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -648,6 +648,16 @@ def compat_5_1(importer: Importer) -> bool:
     return current_is_at_least_5_2 and import_is_at_most_5_1
 
 
+class CameraInfoImporter(SpecificImporter[bpy.types.GeometryNodeCameraInfo]):
+    def deserialize(self):
+        if compat_5_1(self.importer):
+            # https://github.com/Algebraic-UG/tree_clipper/issues/212
+            self.serialization[OUTPUTS][DATA][ITEMS][2][DATA][DEFAULT_VALUE].pop()
+            self.serialization[OUTPUTS][DATA][ITEMS][3][DATA][DEFAULT_VALUE].pop()
+        self.import_all_simple_writable_properties_and_list([INPUTS, OUTPUTS])
+        _import_node_parent(self)
+
+
 class InputStringImporter(SpecificImporter[bpy.types.FunctionNodeInputString]):
     def deserialize(self):
         if compat_5_1(self.importer):

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -676,31 +676,29 @@ class SubdivisionSurfaceImporter(
         _import_node_parent(self)
 
 
-# https://github.com/Algebraic-UG/tree_clipper/issues/209
-def insert_fake_thin_wall_socket(serialization: dict[str, Any]):
-    fake_thin_wall_socket = {
-        "id": -1,
-        "data": {
-            "name": "Thin Wall",
-            "description": "",
-            "hide": False,
-            "enabled": True,
-            "link_limit": 1,
-            "show_expanded": False,
-            "hide_value": False,
-            "pin_gizmo": False,
-            "type": "BOOLEAN",
-            "display_shape": "CIRCLE",
-            "default_value": False,
-        },
-    }
-    serialization[INPUTS][DATA][ITEMS].insert(5, fake_thin_wall_socket)
+FAKE_THIN_WALL_SOCKET = {
+    "id": -1,
+    "data": {
+        "name": "Thin Wall",
+        "description": "",
+        "hide": False,
+        "enabled": True,
+        "link_limit": 1,
+        "show_expanded": False,
+        "hide_value": False,
+        "pin_gizmo": False,
+        "type": "BOOLEAN",
+        "display_shape": "CIRCLE",
+        "default_value": False,
+    },
+}
 
 
 class PrincipledBSDFImporter(SpecificImporter[bpy.types.ShaderNodeBsdfPrincipled]):
     def deserialize(self):
         if compat_5_1(self.importer):
-            insert_fake_thin_wall_socket(self.serialization)
+            # https://github.com/Algebraic-UG/tree_clipper/issues/209
+            self.serialization[INPUTS][DATA][ITEMS].insert(5, FAKE_THIN_WALL_SOCKET)
         self.import_all_simple_writable_properties_and_list([INPUTS, OUTPUTS])
         _import_node_parent(self)
 

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -703,32 +703,30 @@ class PrincipledBSDFImporter(SpecificImporter[bpy.types.ShaderNodeBsdfPrincipled
         _import_node_parent(self)
 
 
-# https://github.com/Algebraic-UG/tree_clipper/issues/208
-def insert_fake_selection_socket(serialization: dict[str, Any]):
-    fake_selection_socket = {
-        "id": -1,
-        "data": {
-            "name": "Selection",
-            "description": "",
-            "hide": False,
-            "enabled": True,
-            "link_limit": 1,
-            "show_expanded": False,
-            "hide_value": True,
-            "pin_gizmo": False,
-            "type": "BOOLEAN",
-            "display_shape": "DIAMOND",
-            "default_value": True,  # maybe this should be false for output
-        },
-    }
-    serialization[INPUTS][DATA][ITEMS].insert(1, fake_selection_socket)
-    serialization[OUTPUTS][DATA][ITEMS].insert(1, fake_selection_socket)
+FAKE_SELECTION_SOCKET = {
+    "id": -1,
+    "data": {
+        "name": "Selection",
+        "description": "",
+        "hide": False,
+        "enabled": True,
+        "link_limit": 1,
+        "show_expanded": False,
+        "hide_value": True,
+        "pin_gizmo": False,
+        "type": "BOOLEAN",
+        "display_shape": "DIAMOND",
+        "default_value": True,  # maybe this should be false for output
+    },
+}
 
 
 class CaptureAttrImporter(SpecificImporter[bpy.types.GeometryNodeCaptureAttribute]):
     def deserialize(self):
         if compat_5_1(self.importer):
-            insert_fake_selection_socket(self.serialization)
+            # https://github.com/Algebraic-UG/tree_clipper/issues/208
+            self.serialization[INPUTS][DATA][ITEMS].insert(1, FAKE_SELECTION_SOCKET)
+            self.serialization[OUTPUTS][DATA][ITEMS].insert(1, FAKE_SELECTION_SOCKET)
 
         self.import_all_simple_writable_properties_and_list(
             # ordering is important, the capture_items implicitly create sockets

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -102,6 +102,7 @@ OVERFLOW = "overflow"
 ALIGN_X = "align_x"
 ALIGN_Y = "align_y"
 PIVOT_MODE = "pivot_mode"
+TEXTBOX_STATE = "textbox_state"
 
 
 # this might not be needed anymore in many cases, because
@@ -645,6 +646,15 @@ def compat_5_1(importer: Importer) -> bool:
         importer.blender_version[0] == 5 and importer.blender_version[1] < 2
     )
     return current_is_at_least_5_2 and import_is_at_most_5_1
+
+
+class InputStringImporter(SpecificImporter[bpy.types.FunctionNodeInputString]):
+    def deserialize(self):
+        if compat_5_1(self.importer):
+            # https://github.com/Algebraic-UG/tree_clipper/issues/211
+            self.serialization[TEXTBOX_STATE] = None
+        self.import_all_simple_writable_properties_and_list([INPUTS, OUTPUTS])
+        _import_node_parent(self)
 
 
 FAKE_BASE_SOCKET = {

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -443,6 +443,16 @@ class TextureNodeGroupImporter(SpecificImporter[bpy.types.TextureNodeGroup]):
 def remove_disabled_in_old_file(importer: Importer, serialization: dict[str, Any]):
     if (bpy.app.version[0] == 5 and bpy.app.version[1] >= 2) or bpy.app.version[0] > 5:
         if importer.blender_version[0] == 5 and importer.blender_version[1] < 2:
+            for disabled in [
+                s[ID] for s in serialization[ITEMS] if not s[DATA][ENABLED]
+            ]:
+                if importer.debug_prints:
+                    print(
+                        f"Removing disabled socket for backward compatibility: {disabled}"
+                    )
+                if disabled in importer.disabled_ids:
+                    raise RuntimeError("Double disabled: {disabled}")
+                importer.disabled_ids.add(disabled)
             serialization[ITEMS] = [s for s in serialization[ITEMS] if s[DATA][ENABLED]]
 
 
@@ -520,6 +530,24 @@ class LinkExporter(SpecificExporter[bpy.types.NodeLink]):
 
 class LinksImporter(SpecificImporter[bpy.types.NodeLinks]):
     def deserialize(self):
+        if compat_5_1(self.importer):
+            # https://github.com/Algebraic-UG/tree_clipper/issues/205
+            def connected_to_disabled(link):
+                return (
+                    link[DATA][FROM_SOCKET] in self.importer.disabled_ids
+                    or link[DATA][TO_SOCKET] in self.importer.disabled_ids
+                )
+
+            if self.importer.debug_prints:
+                for link in self.serialization[ITEMS]:
+                    if connected_to_disabled(link):
+                        print(
+                            f"Removing link from/to disabled for backward compatibility: {link[ID]}"
+                        )
+            self.serialization[ITEMS] = [
+                l for l in self.serialization[ITEMS] if not connected_to_disabled(l)
+            ]
+
         multi_links = []
         for i, link in enumerate(self.serialization[ITEMS]):
             data = link[DATA]

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -647,25 +647,22 @@ def compat_5_1(importer: Importer) -> bool:
     return current_is_at_least_5_2 and import_is_at_most_5_1
 
 
-# https://github.com/Algebraic-UG/tree_clipper/issues/210
-def insert_fake_quality_socket(serialization: dict[str, Any]):
-    fake_quality_socket = {
-        "id": -1,
-        "data": {
-            "name": "Quality",
-            "description": "",
-            "hide": False,
-            "enabled": True,
-            "link_limit": 1,
-            "show_expanded": False,
-            "hide_value": False,
-            "pin_gizmo": False,
-            "type": "INT",
-            "display_shape": "LINE",
-            "default_value": 3,
-        },
-    }
-    serialization[INPUTS][DATA][ITEMS].insert(5, fake_quality_socket)
+FAKE_QUALITY_SOCKET = {
+    "id": -1,
+    "data": {
+        "name": "Quality",
+        "description": "",
+        "hide": False,
+        "enabled": True,
+        "link_limit": 1,
+        "show_expanded": False,
+        "hide_value": False,
+        "pin_gizmo": False,
+        "type": "INT",
+        "display_shape": "LINE",
+        "default_value": 3,
+    },
+}
 
 
 class SubdivisionSurfaceImporter(
@@ -673,7 +670,8 @@ class SubdivisionSurfaceImporter(
 ):
     def deserialize(self):
         if compat_5_1(self.importer):
-            insert_fake_quality_socket(self.serialization)
+            # https://github.com/Algebraic-UG/tree_clipper/issues/210
+            self.serialization[INPUTS][DATA][ITEMS].insert(5, FAKE_QUALITY_SOCKET)
         self.import_all_simple_writable_properties_and_list([INPUTS, OUTPUTS])
         _import_node_parent(self)
 

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -1552,6 +1552,22 @@ class RotateEulerImporter(SpecificImporter[bpy.types.FunctionNodeRotateEuler]):
         _import_node_parent(self)
 
 
+class MathImporter(SpecificImporter[bpy.types.ShaderNodeMath]):
+    """We need to trigger the import of operation first"""
+
+    def deserialize(self) -> None:
+        self.import_all_simple_writable_properties_and_list([INPUTS, OUTPUTS])
+        _import_node_parent(self)
+
+
+class VectorMathImporter(SpecificImporter[bpy.types.ShaderNodeVectorMath]):
+    """We need to trigger the import of operation first"""
+
+    def deserialize(self) -> None:
+        self.import_all_simple_writable_properties_and_list([INPUTS, OUTPUTS])
+        _import_node_parent(self)
+
+
 if (bpy.app.version[0] == 5 and bpy.app.version[1] >= 1) or bpy.app.version[0] > 5:
 
     class FieldToListExporter(SpecificExporter[bpy.types.GeometryNodeFieldToList]):

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -1,6 +1,6 @@
 import bpy
 
-from typing import Type
+from typing import Type, Any
 
 from .specific_abstract import (
     _BUILT_IN_EXPORTER,
@@ -8,6 +8,8 @@ from .specific_abstract import (
     SpecificExporter,
     SpecificImporter,
 )
+
+from .import_nodes import Importer
 
 from .common import (
     DATA,
@@ -436,16 +438,26 @@ class TextureNodeGroupImporter(SpecificImporter[bpy.types.TextureNodeGroup]):
         _import_node_parent(self)
 
 
+# https://github.com/Algebraic-UG/tree_clipper/issues/205
+def remove_disabled_in_old_file(importer: Importer, serialization: dict[str, Any]):
+    if (bpy.app.version[0] == 5 and bpy.app.version[1] >= 2) or bpy.app.version[0] > 5:
+        if importer.blender_version[0] == 5 and importer.blender_version[1] < 2:
+            serialization[ITEMS] = [s for s in serialization[ITEMS] if s[DATA][ENABLED]]
+
+
 class NodeInputsImporter(SpecificImporter[bpy.types.NodeInputs]):
     def deserialize(self):
         expected = len(self.serialization[ITEMS])
         current = len(self.getter())
         if current != expected:
-            raise RuntimeError(
-                f"""{self.from_root.to_str()}
+            remove_disabled_in_old_file(self.importer, self.serialization)
+            expected = len(self.serialization[ITEMS])
+            if current != expected:
+                raise RuntimeError(
+                    f"""{self.from_root.to_str()}
 expected {expected} in-sockets but found {current}
 we currently don't support creating sockets"""
-            )
+                )
 
 
 class NodeOutputsImporter(SpecificImporter[bpy.types.NodeOutputs]):
@@ -453,11 +465,14 @@ class NodeOutputsImporter(SpecificImporter[bpy.types.NodeOutputs]):
         expected = len(self.serialization[ITEMS])
         current = len(self.getter())
         if current != expected:
-            raise RuntimeError(
-                f"""{self.from_root.to_str()}
+            remove_disabled_in_old_file(self.importer, self.serialization)
+            expected = len(self.serialization[ITEMS])
+            if current != expected:
+                raise RuntimeError(
+                    f"""{self.from_root.to_str()}
 expected {expected} out-sockets but found {current}
 we currently don't support creating sockets"""
-            )
+                )
 
 
 class SocketExporter(SpecificExporter[bpy.types.NodeSocket]):

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -1529,6 +1529,14 @@ class BooleanMathImporter(SpecificImporter[bpy.types.FunctionNodeBooleanMath]):
         _import_node_parent(self)
 
 
+class RotateEulerImporter(SpecificImporter[bpy.types.FunctionNodeRotateEuler]):
+    """We need to trigger the import of rotation_type first"""
+
+    def deserialize(self) -> None:
+        self.import_all_simple_writable_properties_and_list([INPUTS, OUTPUTS])
+        _import_node_parent(self)
+
+
 if (bpy.app.version[0] == 5 and bpy.app.version[1] >= 1) or bpy.app.version[0] > 5:
 
     class FieldToListExporter(SpecificExporter[bpy.types.GeometryNodeFieldToList]):

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -647,6 +647,51 @@ def compat_5_1(importer: Importer) -> bool:
     return current_is_at_least_5_2 and import_is_at_most_5_1
 
 
+FAKE_BASE_SOCKET = {
+    "id": -1,
+    "data": {
+        "name": "Base",
+        "description": "",
+        "hide": False,
+        "enabled": False,
+        "link_limit": 1,
+        "show_expanded": False,
+        "hide_value": False,
+        "pin_gizmo": False,
+        "type": "INT",
+        "display_shape": "CIRCLE",
+        "default_value": 10,
+    },
+}
+
+FAKE_PADDING_SOCKET = {
+    "id": -1,
+    "data": {
+        "name": "Padding",
+        "description": "",
+        "hide": False,
+        "enabled": False,
+        "link_limit": 1,
+        "show_expanded": False,
+        "hide_value": False,
+        "pin_gizmo": False,
+        "type": "INT",
+        "display_shape": "CIRCLE",
+        "default_value": 0,
+    },
+}
+
+
+class ValueToStringImporter(SpecificImporter[bpy.types.FunctionNodeValueToString]):
+    def deserialize(self):
+        if compat_5_1(self.importer):
+            # https://github.com/Algebraic-UG/tree_clipper/issues/197
+            self.serialization[INPUTS][DATA][ITEMS].insert(2, FAKE_BASE_SOCKET)
+            self.serialization[INPUTS][DATA][ITEMS].insert(3, FAKE_PADDING_SOCKET)
+        self.import_all_simple_writable_properties_and_list([INPUTS, OUTPUTS])
+        _import_node_parent(self)
+
+
 FAKE_QUALITY_SOCKET = {
     "id": -1,
     "data": {

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -1521,6 +1521,14 @@ class CompareImporter(SpecificImporter[bpy.types.FunctionNodeCompare]):
         _import_node_parent(self)
 
 
+class BooleanMathImporter(SpecificImporter[bpy.types.FunctionNodeBooleanMath]):
+    """We need to trigger the import of operation first"""
+
+    def deserialize(self) -> None:
+        self.import_all_simple_writable_properties_and_list([INPUTS, OUTPUTS])
+        _import_node_parent(self)
+
+
 if (bpy.app.version[0] == 5 and bpy.app.version[1] >= 1) or bpy.app.version[0] > 5:
 
     class FieldToListExporter(SpecificExporter[bpy.types.GeometryNodeFieldToList]):

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -637,6 +637,45 @@ class CaptureAttrExporter(SpecificExporter[bpy.types.GeometryNodeCaptureAttribut
         )
 
 
+def compat_5_1(importer: Importer) -> bool:
+    current_is_at_least_5_2 = (
+        bpy.app.version[0] == 5 and bpy.app.version[1] >= 2
+    ) or bpy.app.version[0] > 5
+    import_is_at_most_5_1 = (
+        importer.blender_version[0] == 5 and importer.blender_version[1] < 2
+    )
+    return current_is_at_least_5_2 and import_is_at_most_5_1
+
+
+# https://github.com/Algebraic-UG/tree_clipper/issues/209
+def insert_fake_thin_wall_socket(serialization: dict[str, Any]):
+    fake_thin_wall_socket = {
+        "id": -1,
+        "data": {
+            "name": "Thin Wall",
+            "description": "",
+            "hide": False,
+            "enabled": True,
+            "link_limit": 1,
+            "show_expanded": False,
+            "hide_value": False,
+            "pin_gizmo": False,
+            "type": "BOOLEAN",
+            "display_shape": "CIRCLE",
+            "default_value": False,
+        },
+    }
+    serialization[INPUTS][DATA][ITEMS].insert(5, fake_thin_wall_socket)
+
+
+class PrincipledBSDFImporter(SpecificImporter[bpy.types.ShaderNodeBsdfPrincipled]):
+    def deserialize(self):
+        if compat_5_1(self.importer):
+            insert_fake_thin_wall_socket(self.serialization)
+        self.import_all_simple_writable_properties_and_list([INPUTS, OUTPUTS])
+        _import_node_parent(self)
+
+
 # https://github.com/Algebraic-UG/tree_clipper/issues/208
 def insert_fake_selection_socket(serialization: dict[str, Any]):
     fake_selection_socket = {
@@ -661,14 +700,8 @@ def insert_fake_selection_socket(serialization: dict[str, Any]):
 
 class CaptureAttrImporter(SpecificImporter[bpy.types.GeometryNodeCaptureAttribute]):
     def deserialize(self):
-        if (bpy.app.version[0] == 5 and bpy.app.version[1] >= 2) or bpy.app.version[
-            0
-        ] > 5:
-            if (
-                self.importer.blender_version[0] == 5
-                and self.importer.blender_version[1] < 2
-            ):
-                insert_fake_selection_socket(self.serialization)
+        if compat_5_1(self.importer):
+            insert_fake_selection_socket(self.serialization)
 
         self.import_all_simple_writable_properties_and_list(
             # ordering is important, the capture_items implicitly create sockets

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -550,6 +550,9 @@ class LinksImporter(SpecificImporter[bpy.types.NodeLinks]):
 
         multi_links = []
         for i, link in enumerate(self.serialization[ITEMS]):
+            if self.importer.debug_prints:
+                print(f"{self.from_root.to_str()}: Importing link {link[ID]}")
+
             data = link[DATA]
             from_socket_id = data[FROM_SOCKET]
             to_socket_id = data[TO_SOCKET]

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -103,6 +103,7 @@ ALIGN_X = "align_x"
 ALIGN_Y = "align_y"
 PIVOT_MODE = "pivot_mode"
 TEXTBOX_STATE = "textbox_state"
+SAMPLE_ATTRIBUTE_ITEMS = "sample_attribute_items"
 
 
 # this might not be needed anymore in many cases, because
@@ -1928,6 +1929,45 @@ if (bpy.app.version[0] == 5 and bpy.app.version[1] >= 1) or bpy.app.version[0] >
                 return
 
             self.import_all_simple_writable_properties_and_list([INPUTS, OUTPUTS])
+            _import_node_parent(self)
+
+
+if (bpy.app.version[0] == 5 and bpy.app.version[1] >= 2) or bpy.app.version[0] > 5:
+
+    class RaycastSampleAttributeItemExporter(
+        SpecificExporter[bpy.types.NodeRaycastSampleAttributeItem]
+    ):
+        def serialize(self):
+            return self.export_all_simple_writable_properties()
+
+    class RaycastSampleAttributeItemsImporter(
+        SpecificImporter[bpy.types.NodeRaycastSampleAttributeItems]
+    ):
+        def deserialize(self):
+            self.getter().clear()
+            for item in self.serialization[ITEMS]:
+                name = _or_default(
+                    item[DATA], bpy.types.NodeRaycastSampleAttributeItem, NAME
+                )
+                socket_type = _map_attribute_type_to_socket_type(
+                    _or_default(
+                        item[DATA],
+                        bpy.types.NodeGeometryCaptureAttributeItem,
+                        DATA_TYPE,
+                    )
+                )
+                if self.importer.debug_prints:
+                    print(
+                        f"{self.from_root.to_str()}: adding item {name} {socket_type}"
+                    )
+                self.getter().new(socket_type=socket_type, name=name)
+
+    class RaycastImporter(SpecificImporter[bpy.types.ShaderNodeRaycast]):
+        def deserialize(self):
+            self.import_all_simple_writable_properties_and_list(
+                # ordering is important, the sample_attribute_items implicitly create sockets
+                [SAMPLE_ATTRIBUTE_ITEMS, ACTIVE_INDEX, INPUTS, OUTPUTS]
+            )
             _import_node_parent(self)
 
 

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -1970,6 +1970,40 @@ if (bpy.app.version[0] == 5 and bpy.app.version[1] >= 2) or bpy.app.version[0] >
             )
             _import_node_parent(self)
 
+    class ClosureToListItemExporter(
+        SpecificExporter[bpy.types.GeometryNodeClosureToListItem]
+    ):
+        def serialize(self):
+            return self.export_all_simple_writable_properties()
+
+    class ClosureToListItemsImporter(
+        SpecificImporter[bpy.types.GeometryNodeClosureToListItems]
+    ):
+        def deserialize(self):
+            self.getter().clear()
+            for item in self.serialization[ITEMS]:
+                name = _or_default(
+                    item[DATA], bpy.types.GeometryNodeClosureToListItem, NAME
+                )
+                socket_type = _or_default(
+                    item[DATA],
+                    bpy.types.GeometryNodeClosureToListItem,
+                    SOCKET_TYPE,
+                )
+                if self.importer.debug_prints:
+                    print(
+                        f"{self.from_root.to_str()}: adding item {name} {socket_type}"
+                    )
+                self.getter().new(socket_type=socket_type, name=name)
+
+    class ClosureToListImporter(SpecificImporter[bpy.types.GeometryNodeClosureToList]):
+        def deserialize(self):
+            self.import_all_simple_writable_properties_and_list(
+                # ordering is important, the list_items implicitly create sockets
+                [LIST_ITEMS, ACTIVE_INDEX, INPUTS, OUTPUTS]
+            )
+            _import_node_parent(self)
+
 
 # now they are cooked and ready to use ~ bon appétit
 BUILT_IN_EXPORTER = _BUILT_IN_EXPORTER

--- a/packages/tree_clipper/src/tree_clipper/specific_handlers.py
+++ b/packages/tree_clipper/src/tree_clipper/specific_handlers.py
@@ -692,6 +692,15 @@ class ValueToStringImporter(SpecificImporter[bpy.types.FunctionNodeValueToString
         _import_node_parent(self)
 
 
+class StringToValueImporter(SpecificImporter[bpy.types.FunctionNodeStringToValue]):
+    def deserialize(self):
+        if compat_5_1(self.importer):
+            # https://github.com/Algebraic-UG/tree_clipper/issues/198
+            self.serialization[INPUTS][DATA][ITEMS].insert(1, FAKE_BASE_SOCKET)
+        self.import_all_simple_writable_properties_and_list([INPUTS, OUTPUTS])
+        _import_node_parent(self)
+
+
 FAKE_QUALITY_SOCKET = {
     "id": -1,
     "data": {

--- a/packages/tree_clipper/tests/test_all_nodes.py
+++ b/packages/tree_clipper/tests/test_all_nodes.py
@@ -26,6 +26,7 @@ def test_all_nodes(node_type: Type[bpy.types.Node]):
             bpy.types.TextureNodeDecompose,
             # TODO: there is a "Gamma" node in the compositor, but it's the "shader version"
             bpy.types.CompositorNodeGamma,
+            bpy.types.GeometryNodeApplySimulatedData,
         ]:
             return
         # skip the output types of the pairs

--- a/packages/tree_clipper/tests/util.py
+++ b/packages/tree_clipper/tests/util.py
@@ -208,7 +208,8 @@ def import_and_check(*, import_file: Path, debug_prints: bool = False):
         )
     )
 
-    assert len(import_report.warnings) == 0
+    if import_report.warnings:
+        raise RuntimeError(f"Import finished with warnings: {import_report.warnings}")
 
 
 def import_and_check_export(

--- a/packages/tree_clipper_addon/src/tree_clipper_addon/blender_manifest.toml
+++ b/packages/tree_clipper_addon/src/tree_clipper_addon/blender_manifest.toml
@@ -21,7 +21,7 @@ tags = ["Import-Export", "Node"]
 blender_version_min = "5.0.0"
 # # Optional: Blender version that the extension does not support, earlier versions are supported.
 # # This can be omitted and defined later on the extensions platform if an issue is found.
-blender_version_max = "5.2.0"
+blender_version_max = "5.3.0"
 
 # License conforming to https://spdx.org/licenses/ (use "SPDX: prefix)
 # https://docs.blender.org/manual/en/dev/advanced/extensions/licenses.html


### PR DESCRIPTION
The operation needs to be set to `Equal` if the `Epsilon` input is to be deserialized.

This shouldn't have worked in 5.1, weird.

Fixes #205 