### PR TITLE
Preliminary Check

### DIFF
--- a/packages/tree_clipper/src/tree_clipper/import_nodes.py
+++ b/packages/tree_clipper/src/tree_clipper/import_nodes.py
@@ -699,4 +699,4 @@ class ImportIntermediate:
 
 
 def preliminary_check(string: str) -> bool:
-    return string.startswith(MAGIC_STRING) or string.startswith("{")
+    return string.startswith((MAGIC_STRING, "{"))

--- a/packages/tree_clipper/src/tree_clipper/import_nodes.py
+++ b/packages/tree_clipper/src/tree_clipper/import_nodes.py
@@ -696,3 +696,7 @@ class ImportIntermediate:
         while self.step():
             pass
         return self.importer.report
+
+
+def preliminary_check(string: str) -> bool:
+    return string.startswith(MAGIC_STRING) or string.startswith("{")

--- a/packages/tree_clipper_addon/src/tree_clipper_addon/__init__.py
+++ b/packages/tree_clipper_addon/src/tree_clipper_addon/__init__.py
@@ -56,10 +56,15 @@ def draw_export_active(self, _context):
     self.layout.operator(SCENE_OT_Tree_Clipper_Export_Active.bl_idname)
 
 
-def draw_import(self, _context):
+def draw_import(self, context):
+    if not SCENE_OT_Tree_Clipper_Import_Clipboard_Prepare.poll(context):
+        import_text = "Import Tree Clipper (Invalid Clipboard Content)"
+    else:
+        import_text = "Import Tree Clipper"
+
     self.layout.operator(
         SCENE_OT_Tree_Clipper_Import_Clipboard_Prepare.bl_idname,
-        text="Import Tree Clipper",
+        text=import_text,
     )
 
 

--- a/packages/tree_clipper_addon/src/tree_clipper_addon/operators_export.py
+++ b/packages/tree_clipper_addon/src/tree_clipper_addon/operators_export.py
@@ -21,6 +21,7 @@ _INTERMEDIATE_EXPORT_CACHE = None
 class SCENE_OT_Tree_Clipper_Export_Prepare(bpy.types.Operator):
     bl_idname = "scene.tree_clipper_export_prepare"
     bl_label = "Export"
+    bl_description = "Export the node tree as a Tree Clipper string."
     bl_options: ClassVar[set[str]] = {"REGISTER"}  # ty:ignore[invalid-attribute-override]
 
     is_material: bpy.props.BoolProperty(name="Top level Material")  # type: ignore

--- a/packages/tree_clipper_addon/src/tree_clipper_addon/operators_import.py
+++ b/packages/tree_clipper_addon/src/tree_clipper_addon/operators_import.py
@@ -25,6 +25,7 @@ TIMER = None
 class SCENE_OT_Tree_Clipper_Import_File_Prepare(bpy.types.Operator):
     bl_idname = "scene.tree_clipper_import_file_prepare"
     bl_label = "Import File"
+    bl_description = "Import a Tree Clipper string from a file."
     bl_options: ClassVar[set[str]] = {"REGISTER"}  # ty:ignore[invalid-attribute-override]
 
     input_file: bpy.props.StringProperty(
@@ -52,6 +53,7 @@ class SCENE_OT_Tree_Clipper_Import_File_Prepare(bpy.types.Operator):
 class SCENE_OT_Tree_Clipper_Import_Clipboard_Prepare(bpy.types.Operator):
     bl_idname = "scene.tree_clipper_import_clipboard_prepare"
     bl_label = "Import Clipboard"
+    bl_description = "Import a Tree Clipper string from the clipboard."
     bl_options: ClassVar[set[str]] = {"REGISTER"}  # ty:ignore[invalid-attribute-override]
 
     def execute(

--- a/packages/tree_clipper_addon/src/tree_clipper_addon/operators_import.py
+++ b/packages/tree_clipper_addon/src/tree_clipper_addon/operators_import.py
@@ -11,7 +11,11 @@ from pathlib import Path
 
 from ._vendor.tree_clipper.common import DEFAULT_FILE
 from ._vendor.tree_clipper.dynamic_pointer import add_all_known_pointer_properties
-from ._vendor.tree_clipper.import_nodes import ImportIntermediate, ImportParameters
+from ._vendor.tree_clipper.import_nodes import (
+    ImportIntermediate,
+    ImportParameters,
+    preliminary_check,
+)
 from ._vendor.tree_clipper.specific_handlers import (
     BUILT_IN_IMPORTER,
 )
@@ -55,6 +59,10 @@ class SCENE_OT_Tree_Clipper_Import_Clipboard_Prepare(bpy.types.Operator):
     bl_label = "Import Clipboard"
     bl_description = "Import a Tree Clipper string from the clipboard."
     bl_options: ClassVar[set[str]] = {"REGISTER"}  # ty:ignore[invalid-attribute-override]
+
+    @classmethod
+    def poll(cls, context: bpy.types.Context) -> bool:
+        return preliminary_check(bpy.context.window_manager.clipboard)  # ty:ignore[unresolved-attribute]
 
     def execute(
         self, context: bpy.types.Context

--- a/packages/tree_clipper_addon/src/tree_clipper_addon/panel.py
+++ b/packages/tree_clipper_addon/src/tree_clipper_addon/panel.py
@@ -5,6 +5,7 @@ from .operators_import import (
     SCENE_OT_Tree_Clipper_Import_Clipboard_Prepare,
     SCENE_OT_Tree_Clipper_Import_File_Prepare,
 )
+from ._vendor.tree_clipper.import_nodes import preliminary_check
 
 
 class SCENE_PT_Tree_Clipper_Panel(bpy.types.Panel):
@@ -39,5 +40,11 @@ class SCENE_PT_Tree_Clipper_Panel(bpy.types.Panel):
         self.layout.separator()  # ty:ignore[possibly-missing-attribute]
 
         import_col = self.layout.column()  # ty:ignore[possibly-missing-attribute]
-        import_col.operator(SCENE_OT_Tree_Clipper_Import_Clipboard_Prepare.bl_idname)
+        if SCENE_OT_Tree_Clipper_Import_Clipboard_Prepare.poll(context):
+            import_text = SCENE_OT_Tree_Clipper_Import_Clipboard_Prepare.bl_label
+        else:
+            import_text = "Invalid Clipboard Content"
+        import_col.operator(
+            SCENE_OT_Tree_Clipper_Import_Clipboard_Prepare.bl_idname, text=import_text
+        )
         import_col.operator(SCENE_OT_Tree_Clipper_Import_File_Prepare.bl_idname)

--- a/packages/tree_clipper_addon/src/tree_clipper_addon/panel.py
+++ b/packages/tree_clipper_addon/src/tree_clipper_addon/panel.py
@@ -5,7 +5,6 @@ from .operators_import import (
     SCENE_OT_Tree_Clipper_Import_Clipboard_Prepare,
     SCENE_OT_Tree_Clipper_Import_File_Prepare,
 )
-from ._vendor.tree_clipper.import_nodes import preliminary_check
 
 
 class SCENE_PT_Tree_Clipper_Panel(bpy.types.Panel):

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,6 @@ version = 1
 revision = 3
 requires-python = "==3.13.*"
 
-[options]
-prerelease-mode = "allow"
-
 [manifest]
 members = [
     "tree-clipper",


### PR DESCRIPTION
It's easy to execute the import operator with an invalid string.

We can have a cheap check that avoids this in many cases.

<img width="365" height="205" alt="image" src="https://github.com/user-attachments/assets/a0415e59-b9c8-44d2-aa79-74492e6c671e" />
